### PR TITLE
Fix bug in connection status change (regression in v1.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased 
+### Fixed
+- The new "Change Status" check (from v1.0.8) does not work, since the old status is already set previously
 
 ## [1.1.3] - 2020-12-25
 ### Changed

--- a/src/main/java/de/csdev/ebus/core/EBusControllerBase.java
+++ b/src/main/java/de/csdev/ebus/core/EBusControllerBase.java
@@ -214,11 +214,6 @@ public abstract class EBusControllerBase extends Thread implements IEBusControll
             return;
         }
 
-        // only run on a real status change
-        if (getConnectionStatus() == status) {
-            return;
-        }
-
         if (threadPool == null || threadPool.isTerminated()) {
             logger.warn(THREADPOOL_NOT_READY);
             return;
@@ -326,8 +321,12 @@ public abstract class EBusControllerBase extends Thread implements IEBusControll
 
         Objects.requireNonNull(status, "status");
 
-        this.connectionStatus = status;
-        fireOnEBusConnectionStatusChange(status);
+
+        // only run on a real status change
+        if (this.connectionStatus != status) {
+            this.connectionStatus = status;
+            fireOnEBusConnectionStatusChange(status);
+        }
     }
 
     @Override


### PR DESCRIPTION
- The new "Change Status" check does not work, since the old status is already set previously