### PR TITLE
Enhance error handling for invalid config files

### DIFF
--- a/src/main/java/de/csdev/ebus/cfg/EBusConfigurationReaderException.java
+++ b/src/main/java/de/csdev/ebus/cfg/EBusConfigurationReaderException.java
@@ -8,8 +8,6 @@
  */
 package de.csdev.ebus.cfg;
 
-import java.text.MessageFormat;
-
 /**
  * @author Christian Sowada - Initial contribution
  *
@@ -18,20 +16,19 @@ public class EBusConfigurationReaderException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
-    public EBusConfigurationReaderException(final String message, final Throwable cause, final Object... args) {
-        super(String.format(message, args), cause);
+    public EBusConfigurationReaderException(final String message) {
+        super(message);
     }
 
     public EBusConfigurationReaderException(final String message, final Object... args) {
-        super(MessageFormat.format(message, args));
-    }
-
-    public EBusConfigurationReaderException(final String message) {
-        super(message);
+        super(String.format(message, args));
     }
 
     public EBusConfigurationReaderException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    public EBusConfigurationReaderException(final String message, final Throwable cause, final Object... args) {
+        super(String.format(message, args), cause);
+    }
 }

--- a/src/main/java/de/csdev/ebus/cfg/IEBusConfigurationReader.java
+++ b/src/main/java/de/csdev/ebus/cfg/IEBusConfigurationReader.java
@@ -25,39 +25,41 @@ import de.csdev.ebus.command.datatypes.EBusTypeRegistry;
 @NonNullByDefault
 public interface IEBusConfigurationReader {
 
-    /**
-     * Loads all build-in command collections implemented by the reader
-     *
-     * @return
-     */
-    public List<IEBusCommandCollection> loadBuildInConfigurationCollections();
+        /**
+         * Loads all build-in command collections implemented by the reader
+         *
+         * @return
+         */
+        public List<IEBusCommandCollection> loadBuildInConfigurationCollections()
+                        throws EBusConfigurationReaderException, IOException;
 
-    /**
-     * Loads the configuration from an InputStream and returns a command collection
-     *
-     * @param url
-     * @return
-     * @throws EBusConfigurationReaderException
-     * @throws IOException
-     */
-    public @Nullable IEBusCommandCollection loadConfigurationCollection(final URL url)
-            throws EBusConfigurationReaderException, IOException;
+        /**
+         * Loads the configuration from an InputStream and returns a command collection
+         *
+         * @param url
+         * @return
+         * @throws EBusConfigurationReaderException
+         * @throws IOException
+         */
+        public @Nullable IEBusCommandCollection loadConfigurationCollection(final URL url)
+                        throws EBusConfigurationReaderException, IOException;
 
-    /**
-     * @param url
-     * @return
-     */
-    public List<IEBusCommandCollection> loadConfigurationCollectionBundle(final URL url);
+        /**
+         * @param url
+         * @return
+         */
+        public List<IEBusCommandCollection> loadConfigurationCollectionBundle(final URL url)
+                        throws EBusConfigurationReaderException, IOException;
 
-    /**
-     * Sets the eBUS type registry to use
-     *
-     * @param ebusTypes
-     */
-    public void setEBusTypes(final EBusTypeRegistry ebusTypes);
+        /**
+         * Sets the eBUS type registry to use
+         *
+         * @param ebusTypes
+         */
+        public void setEBusTypes(final EBusTypeRegistry ebusTypes);
 
-    /**
-     * Clears all internal states
-     */
-    public void clear();
+        /**
+         * Clears all internal states
+         */
+        public void clear();
 }

--- a/src/main/java/de/csdev/ebus/command/EBusCommandRegistry.java
+++ b/src/main/java/de/csdev/ebus/command/EBusCommandRegistry.java
@@ -74,15 +74,19 @@ public class EBusCommandRegistry {
                 loadBuildInCommandCollections();
             }
 
-        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException | EBusTypeException e) {
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException | EBusTypeException
+                | EBusConfigurationReaderException | IOException e) {
             throw new IllegalStateException(e);
         }
     }
 
     /**
      * Loads all build-in command collections
+     * 
+     * @throws IOException
+     * @throws EBusConfigurationReaderException
      */
-    public void loadBuildInCommandCollections() {
+    public void loadBuildInCommandCollections() throws EBusConfigurationReaderException, IOException {
         List<@NonNull IEBusCommandCollection> loadBuildInConfigurations = reader.loadBuildInConfigurationCollections();
 
         if (!loadBuildInConfigurations.isEmpty()) {
@@ -97,23 +101,15 @@ public class EBusCommandRegistry {
      *
      * @param url
      */
-    public void loadCommandCollection(@NonNull URL url) {
-
+    public void loadCommandCollection(@NonNull URL url) throws EBusConfigurationReaderException, IOException {
         Objects.requireNonNull(url);
-
-        try {
-            addCommandCollection(reader.loadConfigurationCollection(url));
-
-        } catch (EBusConfigurationReaderException | IOException e) {
-            logger.error("error!", e);
-        }
-
+        addCommandCollection(reader.loadConfigurationCollection(url));
     }
 
     /**
      * @param url
      */
-    public void loadCommandCollectionBundle(@NonNull URL url) {
+    public void loadCommandCollectionBundle(@NonNull URL url) throws EBusConfigurationReaderException, IOException  {
 
         Objects.requireNonNull(url);
 

--- a/src/test/java/de/csdev/ebus/cfg/EBusConfigurationBundleTest.java
+++ b/src/test/java/de/csdev/ebus/cfg/EBusConfigurationBundleTest.java
@@ -10,6 +10,7 @@ package de.csdev.ebus.cfg;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.net.URL;
 
 import org.junit.Test;
@@ -24,7 +25,7 @@ import de.csdev.ebus.command.EBusCommandRegistry;
 public class EBusConfigurationBundleTest {
 
     @Test
-    public void test_BuildMasterTelegram() {
+    public void test_BuildMasterTelegram() throws EBusConfigurationReaderException, IOException {
 
         URL url = EBusCommandRegistry.class.getResource("/index-configuration.json");
         assertNotNull(url);

--- a/src/test/java/de/csdev/ebus/cfg/EBusConfigurationTest.java
+++ b/src/test/java/de/csdev/ebus/cfg/EBusConfigurationTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016-2020 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package de.csdev.ebus.cfg;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.csdev.ebus.cfg.std.EBusConfigurationReader;
+import de.csdev.ebus.command.EBusCommandRegistry;
+
+/**
+ * @author Christian Sowada - Initial contribution
+ *
+ */
+public class EBusConfigurationTest {
+
+    EBusCommandRegistry commandRegistry;
+
+    @Before
+    public void before() throws IOException, EBusConfigurationReaderException {
+        commandRegistry = new EBusCommandRegistry(EBusConfigurationReader.class, true);
+    }
+
+    private void load(String resourceFile) throws EBusConfigurationReaderException, IOException {
+        commandRegistry.loadCommandCollection(EBusConfigurationTest.class.getResource(resourceFile));
+    }
+
+    @Test
+    public void testConfigurationWithoutId() {
+        try {
+            load("/invalid-cfgs/invalid-configuration-empty-id.json");
+            fail("The configuration should fail due to missing property 'id' !");
+        } catch (EBusConfigurationReaderException e) {
+            // expected result
+
+        } catch(Exception e) {
+            fail("Unexpected exception occured!");
+        }
+    }
+
+    @Test
+    public void testConfigurationWithoutLabel() {
+        try {
+            load("/invalid-cfgs/invalid-configuration-empty-label.json");
+            fail("The configuration should fail due to missing property 'label' !");
+        } catch (EBusConfigurationReaderException e) {
+            // expected result
+
+        } catch(Exception e) {
+            fail("Unexpected exception occured!");
+        }
+    }
+
+    @Test
+    public void testConfigurationWithoutDescription() {
+        try {
+            load("/invalid-cfgs/invalid-configuration-empty-description.json");
+            fail("The configuration should fail due to missing property 'description' !");
+        } catch (EBusConfigurationReaderException e) {
+            // expected result
+
+        } catch(Exception e) {
+            fail("Unexpected exception occured!");
+        }
+    }
+}

--- a/src/test/java/de/csdev/ebus/wip/EBusConfigurationTemplateTest.java
+++ b/src/test/java/de/csdev/ebus/wip/EBusConfigurationTemplateTest.java
@@ -10,10 +10,12 @@ package de.csdev.ebus.wip;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import de.csdev.ebus.cfg.EBusConfigurationReaderException;
 import de.csdev.ebus.cfg.std.EBusConfigurationReader;
 import de.csdev.ebus.command.EBusCommandRegistry;
 import de.csdev.ebus.command.IEBusCommand;
@@ -29,7 +31,7 @@ import de.csdev.ebus.command.IEBusValue;
 public class EBusConfigurationTemplateTest {
 
     // @Test
-    public void test_BuildMasterTelegram() {
+    public void test_BuildMasterTelegram() throws EBusConfigurationReaderException, IOException {
 
         EBusCommandRegistry registry = new EBusCommandRegistry(EBusConfigurationReader.class);
         registry.loadBuildInCommandCollections();

--- a/src/test/java/de/csdev/ebus/wip/EBusCustomParserTest.java
+++ b/src/test/java/de/csdev/ebus/wip/EBusCustomParserTest.java
@@ -10,12 +10,14 @@ package de.csdev.ebus.wip;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.csdev.ebus.cfg.EBusConfigurationReaderException;
 import de.csdev.ebus.cfg.std.EBusConfigurationReader;
 import de.csdev.ebus.command.EBusCommandException;
 import de.csdev.ebus.command.EBusCommandRegistry;
@@ -35,7 +37,7 @@ public class EBusCustomParserTest {
     private final Logger logger = LoggerFactory.getLogger(EBusCustomParserTest.class);
 
     // @Test
-    public void test_BuildMasterTelegram() {
+    public void test_BuildMasterTelegram() throws EBusConfigurationReaderException, IOException {
 
         URL url = EBusConfigurationReader.class.getResource("/custom.json");
         assertNotNull(url);

--- a/src/test/resources/invalid-cfgs/invalid-configuration-empty-description.json
+++ b/src/test/resources/invalid-cfgs/invalid-configuration-empty-description.json
@@ -1,0 +1,64 @@
+{
+    "id":           "test",
+    "vendor":       "TestCase",
+    "label":        "Test Case",
+    "x-description":"Test Case commands",
+    
+    "authors":      ["Christian Sowada, opensource@cs-dev.de"],
+    
+    "commands":
+    [
+
+        {
+            "label":    "Identification of eBUS devices - Request",
+            "id":       "common.identification",
+            "command":  "99 04",
+    
+            "template": [
+                {"name": "vendor", "type": "byte", "label": "Vendor"},
+                {"name": "device_id", "type": "bytes", "length": 5, "label": "Device ID"},
+                {"name": "software_version", "type": "version", "label": "Software Version"},
+                {"name": "hardware_version", "type": "version", "label": "Hardware Version"}
+            ],
+    
+            "broadcast": {
+                "master": [
+                    {"type": "template-block"}
+                ]
+            },
+    
+            "get": {
+                "slave": [
+                    {"type": "template-block"}
+                ]
+            }
+        },
+    
+        {
+            "label":    "Inquiry of Existence",
+            "id":       "common.inquiry_of_existence",
+            "command":  "99 FE",
+            "broadcast":{}
+        },
+    
+        {
+            "label":    "Sign of Life",
+            "id":       "common.sign_of_life",
+            "command":  "99 FF",
+            "broadcast":{}
+        },
+    
+        {
+            "label":    "Error Message",
+            "id":       "common.error",
+            "command":  "FE 99",
+    
+            "broadcast": {
+                "master": [
+                    {"type": "string", "name":"error", "length": 10}
+                    
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/invalid-cfgs/invalid-configuration-empty-id.json
+++ b/src/test/resources/invalid-cfgs/invalid-configuration-empty-id.json
@@ -1,0 +1,64 @@
+{
+    "x-id":         "test",
+    "vendor":       "TestCase",
+    "label":        "Test Case",
+    "description":  "Test Case commands",
+    
+    "authors":      ["Christian Sowada, opensource@cs-dev.de"],
+    
+    "commands":
+    [
+
+        {
+            "label":    "Identification of eBUS devices - Request",
+            "id":       "common.identification",
+            "command":  "99 04",
+    
+            "template": [
+                {"name": "vendor", "type": "byte", "label": "Vendor"},
+                {"name": "device_id", "type": "bytes", "length": 5, "label": "Device ID"},
+                {"name": "software_version", "type": "version", "label": "Software Version"},
+                {"name": "hardware_version", "type": "version", "label": "Hardware Version"}
+            ],
+    
+            "broadcast": {
+                "master": [
+                    {"type": "template-block"}
+                ]
+            },
+    
+            "get": {
+                "slave": [
+                    {"type": "template-block"}
+                ]
+            }
+        },
+    
+        {
+            "label":    "Inquiry of Existence",
+            "id":       "common.inquiry_of_existence",
+            "command":  "99 FE",
+            "broadcast":{}
+        },
+    
+        {
+            "label":    "Sign of Life",
+            "id":       "common.sign_of_life",
+            "command":  "99 FF",
+            "broadcast":{}
+        },
+    
+        {
+            "label":    "Error Message",
+            "id":       "common.error",
+            "command":  "FE 99",
+    
+            "broadcast": {
+                "master": [
+                    {"type": "string", "name":"error", "length": 10}
+                    
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/invalid-cfgs/invalid-configuration-empty-label.json
+++ b/src/test/resources/invalid-cfgs/invalid-configuration-empty-label.json
@@ -1,0 +1,64 @@
+{
+    "id":           "test",
+    "vendor":       "TestCase",
+    "x-label":      "Test Case",
+    "description":  "Test Case commands",
+    
+    "authors":      ["Christian Sowada, opensource@cs-dev.de"],
+    
+    "commands":
+    [
+
+        {
+            "label":    "Identification of eBUS devices - Request",
+            "id":       "common.identification",
+            "command":  "99 04",
+    
+            "template": [
+                {"name": "vendor", "type": "byte", "label": "Vendor"},
+                {"name": "device_id", "type": "bytes", "length": 5, "label": "Device ID"},
+                {"name": "software_version", "type": "version", "label": "Software Version"},
+                {"name": "hardware_version", "type": "version", "label": "Hardware Version"}
+            ],
+    
+            "broadcast": {
+                "master": [
+                    {"type": "template-block"}
+                ]
+            },
+    
+            "get": {
+                "slave": [
+                    {"type": "template-block"}
+                ]
+            }
+        },
+    
+        {
+            "label":    "Inquiry of Existence",
+            "id":       "common.inquiry_of_existence",
+            "command":  "99 FE",
+            "broadcast":{}
+        },
+    
+        {
+            "label":    "Sign of Life",
+            "id":       "common.sign_of_life",
+            "command":  "99 FF",
+            "broadcast":{}
+        },
+    
+        {
+            "label":    "Error Message",
+            "id":       "common.error",
+            "command":  "FE 99",
+    
+            "broadcast": {
+                "master": [
+                    {"type": "string", "name":"error", "length": 10}
+                    
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- Add better exception messages for invalid configuration files
- Throw ``EBusConfigurationReaderException``, ``IOException`` instead
 logging as error
 - Add TestCases for invalid json configuration files
- Align ``EBusConfigurationReaderException`` to String.format